### PR TITLE
Makefile: add an ability to specify global root

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,8 @@ ploop: $(SOURCES)
 	go build -o ploop .
 
 install: ploop
-	cp ploop /usr/libexec/kubernetes/kubelet-plugins/volume/exec/virtuozzo~ploop/ploop
+	mkdir -p $(DESTDIR)/usr/libexec/kubernetes/kubelet-plugins/volume/exec/virtuozzo~ploop/ploop
+	cp ploop $(DESTDIR)/usr/libexec/kubernetes/kubelet-plugins/volume/exec/virtuozzo~ploop/ploop
 
 wrapper-journald: ploop
 	cp ploop-journld.sh /usr/libexec/kubernetes/kubelet-plugins/volume/exec/virtuozzo~ploop/ploop


### PR DESCRIPTION
DESTDIR is used to specify global root where all components will be placed

Signed-off-by: Andrei Vagin <avagin@virtuozzo.com>