### PR TITLE
Return error on already mounted ploop

### DIFF
--- a/main.go
+++ b/main.go
@@ -236,11 +236,7 @@ func (p Ploop) Mount(target string, options map[string]string) (*flexvolume.Resp
 		}, nil
 	} else {
 
-		return &flexvolume.Response{
-			Status:  flexvolume.StatusSuccess,
-			Message: "Ploop volume already mounted",
-		}, nil
-
+		return nil, fmt.Errorf("Ploop volume already mounted")
 	}
 }
 


### PR DESCRIPTION
Currently ploop flexvol driver supports only ReadWriteOnce access mode.
Due to this reason multiple mounts are error.
Signed-off-by: Alexander Burluka <aburluka@virtuozzo.com>