### PR TITLE
Remove unnecessary mkdir call

### DIFF
--- a/main.go
+++ b/main.go
@@ -170,12 +170,6 @@ func prepareVstorage(clusterName, clusterPasswd string, mount string) error {
 }
 
 func (p Ploop) Mount(target string, options map[string]string) (*flexvolume.Response, error) {
-	// make the target directory we're going to mount to
-	err := os.MkdirAll(target, 0700)
-	if err != nil {
-		return nil, err
-	}
-
 	path := p.path(options)
 
 	readonly := false


### PR DESCRIPTION
K8s creates mount target directory so there is no need to do it manually
Signed-off-by: Alexander Burluka <aburluka@virtuozzo.com>