### PR TITLE
Return StatusNotSupported from GetVolumeName()

### DIFF
--- a/main.go
+++ b/main.go
@@ -129,13 +129,8 @@ func (p Ploop) path(options map[string]string) string {
 }
 
 func (p Ploop) GetVolumeName(options map[string]string) (*flexvolume.Response, error) {
-	if options["volumeID"] == "" {
-		return nil, fmt.Errorf("Must specify a volume id")
-	}
-
 	return &flexvolume.Response{
-		Status:     flexvolume.StatusSuccess,
-		VolumeName: options["clusterName"] + "|" + p.path(options),
+		Status: flexvolume.StatusNotSupported,
 	}, nil
 }
 


### PR DESCRIPTION
We don't need it and actually it is not used in kubernetes now:
v1.7.0-beta.2~1^2~2^2 ("Remove broken getvolumename and pass
PV or volume name to attach call")

But if kubernetes will start to use it again, this will affect a format
of volume names in node.volumesInUse, but we construct these names in
ap-api-snapshots.

Signed-off-by: Andrei Vagin <avagin@virtuozzo.com>