### PR TITLE
Read creds from env if secretFromSystem is true

### DIFF
--- a/main.go
+++ b/main.go
@@ -138,7 +138,7 @@ func (p Ploop) Init() (*flexvolume.Response, error) {
 
 func (p Ploop) realWorkingDir(options map[string]string) string {
 	realDir := workingDir
-	if options["secretFromSystem"] == "true" {
+	if options["optionsFromSystem"] == "true" {
 		realDir = os.Getenv("kubeVstorageWorkingDir")
 	}
 	return realDir
@@ -231,25 +231,29 @@ func (p Ploop) umountPloop(statePath string) error {
 }
 
 func (p Ploop) Mount(target string, options map[string]string) (*flexvolume.Response, error) {
+	var clusterName, clusterPassword string
 	path := p.path(options)
 
 	readonly := false
 	if options["kubernetes.io/readwrite"] == "ro" {
 		readonly = true
 	}
-	if options["secretFromSystem"] == "true" {
-		options["kubernetes.io/secret/clusterName"] = os.Getenv("kubeVstorageClusterName")
-		options["kubernetes.io/secret/clusterPassword"] = os.Getenv("kubeVstorageClusterPassword")
+	if options["optionsFromSystem"] == "true" {
+		clusterName     = os.Getenv("kubeVstorageClusterName")
+		clusterPassword = os.Getenv("kubeVstorageClusterPassword")
+	}else{
+		clusterName     = options["kubernetes.io/secret/clusterName"]
+		clusterPassword = options["kubernetes.io/secret/clusterPassword"]
 	}
 
 	if options["kubernetes.io/secret/clusterName"] != "" {
-		_cluster, err := base64.StdEncoding.DecodeString(options["kubernetes.io/secret/clusterName"])
+		_cluster, err := base64.StdEncoding.DecodeString(clusterName)
 		if err != nil {
 			return nil, fmt.Errorf("Unable to decode a cluster name: %v", err.Error())
 		}
 		cluster := string(_cluster)
 
-		_passwd, err := base64.StdEncoding.DecodeString(options["kubernetes.io/secret/clusterPassword"])
+		_passwd, err := base64.StdEncoding.DecodeString(clusterPassword)
 		if err != nil {
 			return nil, fmt.Errorf("Unable to decode a cluster password: %v", err.Error())
 		}
@@ -321,11 +325,7 @@ func (p Ploop) Mount(target string, options map[string]string) (*flexvolume.Resp
 }
 
 func (p Ploop) Unmount(mount string) (*flexvolume.Response, error) {
-	err := syscall.Unmount(mount, 0)
-	if err == syscall.EINVAL {
-		//This isn't a mount point, continue and allow the ploop volume to be cleaned up on retry
-		glog.Infof("%s isn't a mount point",mount)
-	} else if err != nil {
+	if err := syscall.Unmount(mount, 0); err != nil {
 		return nil, err
 	}
 

--- a/main.go
+++ b/main.go
@@ -246,7 +246,7 @@ func (p Ploop) Mount(target string, options map[string]string) (*flexvolume.Resp
 		clusterPassword = options["kubernetes.io/secret/clusterPassword"]
 	}
 
-	if options["kubernetes.io/secret/clusterName"] != "" {
+	if clusterName != "" {
 		_cluster, err := base64.StdEncoding.DecodeString(clusterName)
 		if err != nil {
 			return nil, fmt.Errorf("Unable to decode a cluster name: %v", err.Error())

--- a/main.go
+++ b/main.go
@@ -326,7 +326,7 @@ func (p Ploop) Unmount(mount string) (*flexvolume.Response, error) {
 	if err == syscall.EINVAL {
 		//This isn't a mount point, continue and allow the ploop volume to be cleaned up on retry
 		glog.Infof("%s isn't a mount point",mount)
-	} elif err != nil {
+	} else if err != nil {
 		return nil, err
 	}
 

--- a/main.go
+++ b/main.go
@@ -10,7 +10,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"syscall"
-	"strings"
 
 	"github.com/jaxxstorm/flexvolume"
 	"github.com/kolyshkin/goploop-cli"


### PR DESCRIPTION
This PR https://github.com/virtuozzo/external-storage/pull/35 adds a new flag to allow the user to store the Secret object in the kube-system namespace. 
If this flag is enabled in the provisioner, _ploop-flexvol_ will not have the credentials added to _kubernetes.io/secret/clusterName_ / _kubernetes.io/secret/clusterPassword_, so in this case, the credentials are read from the environment.