### PR TITLE
Fixed unmount race condition

### DIFF
--- a/main.go
+++ b/main.go
@@ -309,7 +309,11 @@ func (p Ploop) Mount(target string, options map[string]string) (*flexvolume.Resp
 }
 
 func (p Ploop) Unmount(mount string) (*flexvolume.Response, error) {
-	if err := syscall.Unmount(mount, 0); err != nil {
+	err := syscall.Unmount(mount, 0)
+	if err == syscall.EINVAL {
+		//This isn't a mount point, continue and allow the ploop volume to be cleaned up on retry
+		glog.Infof("%s isn't a mount point",mount)
+	} else if err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
If the volume is busy when the kubelet tries to umount it, the call to
Umount will fail.
The next attemtps will fail as well as the volume has already been
unmounted and the ploop volume never gets cleaned up.
This patch addresses this race condition